### PR TITLE
Solve shift/reduce conflicts for usertype.

### DIFF
--- a/example.gs
+++ b/example.gs
@@ -39,6 +39,8 @@ func main() int{
   int i;
   float t [s];
   float acc [m][s -2];
+  Num number;
+  Person student;
   
   a = 10;
   b = 18.1;

--- a/gosciparse.mly
+++ b/gosciparse.mly
@@ -15,7 +15,8 @@ open Ast
 %token <float> FLIT
 %token <char> CLIT
 %token <string> SLIT
-%token <string> ID
+%token <string> LID
+%token <string> UID
 %token EOF
 
 /* For parsing */
@@ -51,9 +52,13 @@ vdecl_list:
   /*nothing*/ { [] }
   | vdecl SEMI vdecl_list  {  $1 :: $3 }
 
+ID:
+  | UID {$1}
+  | LID {$1}
+
 /* int x */
 vdecl:
-  typ ID unit_expr_opt { ($1, $2, $3) }
+  typ LID unit_expr_opt { ($1, $2, $3) }
 
 typ:
     INT    { Int    }
@@ -61,7 +66,7 @@ typ:
   | FLOAT  { Float  }
   | CHAR   { Char   }
   | STRING { Str }
-  // | ID     { UserType($1) }
+  | UID     { UserType($1) }
 
 unit_expr_opt:
   /*nothing*/                                  { [] }
@@ -191,7 +196,7 @@ labeled_stmt:
 
 
 label:
-    ID { $1 }
+    LID { $1 }
 
 
 // empty_stmt:
@@ -317,7 +322,7 @@ expr:
   | FLIT unit_expr_opt  { FloatLit($1, $2)       }
   | CLIT                { CharLit($1)            }
   | SLIT                { StrLit($1)             }
-  | ID                  { Id($1)                 }
+  | LID                  { Id($1)                 }
   | expr PLUS   expr    { Binop($1, Add,   $3)   }
   | expr MINUS  expr    { Binop($1, Sub,   $3)   }
   | expr MUL    expr    { Binop($1, Mul,   $3)   }
@@ -336,10 +341,10 @@ expr:
   | MINUS  expr         { Unaop(Neg,       $2)   }
   // | INC    expr         { Unaop(Inc,       $2)   }
   // | DEC    expr         { Unaop(Dec,       $2)   }
-  | ID ASSIGN expr      { Assign($1,       $3)   }
+  | LID ASSIGN expr      { Assign($1,       $3)   }
   | LPAREN expr RPAREN  { Paren(           $2)   }
   /* call */
-  | ID LPAREN args_opt RPAREN { Call ($1, $3)  }
+  | LID LPAREN args_opt RPAREN { Call ($1, $3)  }
 
 /* args_opt*/
 args_opt:
@@ -423,4 +428,5 @@ one_token:
   | FLIT    { "FLOAT(" ^ string_of_float $1 ^ ")" }
   | CLIT    { "CHAR(" ^ String.make 1 $1 ^ ")" }
   | SLIT    { "STRING(" ^ $1 ^ ")" }
-  | ID      { "ID(" ^ $1 ^ ")" }
+  | LID      { "LID(" ^ $1 ^ ")" }
+  | UID      { "UID(" ^ $1 ^ ")" }

--- a/scanner.mll
+++ b/scanner.mll
@@ -4,6 +4,8 @@
 
 let digit = ['0'-'9']
 let letter = ['a'-'z' 'A'-'Z']
+let letter_lower = ['a'-'z']
+let letter_upper = ['A'-'Z']
 let char_lit = digit | letter
 let exp = ('e'|'E') ('+'|'-')? digit+
 let float_lit = digit+ '.' digit* exp? | digit+ exp | '.' digit+ exp?
@@ -76,7 +78,8 @@ rule token = parse
 | float_lit as lem                   { FLIT(float_of_string lem) }
 | '\'' (char_lit? as lem) '\''       { CLIT(lem.[0]) }
 | '\"' (char_lit* as lem) '\"'       { SLIT(lem) }
-| letter (digit | letter)* as lem    { ID(lem) }
+| letter_lower (digit | letter)* as lem    { LID(lem) }
+| letter_upper (digit | letter)* as lem    { UID(lem) }
 | eof { EOF }
 | _ as char { raise (Failure("illegal character " ^ Char.escaped char)) }
 


### PR DESCRIPTION
Add usertype instantiation in example.gs.

Details:
Create UID and LID to replace ID.
Use LID for variables and lables.
Use UID for usertypes.